### PR TITLE
Fix background-size scaling

### DIFF
--- a/src/views/Base.vue
+++ b/src/views/Base.vue
@@ -27,6 +27,7 @@
 
     .bg {
         background-image: $background-image;
+        background-size: cover;
         position: fixed;
         left: 0;
         right: 0;


### PR DESCRIPTION
Originally fixed in #6 but may have been regressed later on. Currently on my 1440p display the background will tile. This change fixes the tiling and forces the background image to scale/cover the entire background.