### PR TITLE
Hebrew Translation

### DIFF
--- a/src/translations.js
+++ b/src/translations.js
@@ -88,6 +88,29 @@ const translations = {
         trigger: 'Presiona Espacio o Enter para iniciar sesión',
         password: 'Contraseña...'
     },
+    
+    // Hebrew (TODO)
+    'he': {
+        trigger: 'לחץ על רווח או Enter כדי להכנס',
+        password: 'ססמה...',
+        
+        shutdown: 'מכבה...',
+        suspend: 'משהה...',
+        restart: 'מפעיל מחדש...',
+
+        setup: 'הגדרות',
+        disableSplash: 'בטל מסך קדמי (מסך "לחץ Enter")',
+        disableSplashText: 'בטל טקסט של מסך קדמי (רק שעון)',
+        disableIntro: 'בטל הקדמה (סמל מערגת הפעלה)',
+        disableFade: 'בטל עמעום לשחור בכניסה',
+        roundAvatar: 'יצגן עגול',
+        disableAvatar: 'בטל יצגן',
+        disableZoom: 'בטל מיקוד x2 (תיקון למסך גדול)',
+        clock12: 'תבנית שעון של 12 שעות',
+        capsLock: 'נעילת Caps פעילה',
+
+        primaryColor: 'צבע ראשי'
+    },
 
     // More ? PR opens !
 };


### PR DESCRIPTION
I have added Hebrew to the list of supported languages.
A few issues:
   1. Due to there being no direct translation for some of the words, I either needed to leave a certain word untranslated (to conform with how things are used in Israel), or translate to a slightly different meaning.
       1a. "Enter" needed to be left untranslated.
       1b. "Setup" needed to be translated as "Settings"
       1c. I was unable to properly translate "splash", so for the time being I am using the translation for "Front screen", since that is the closest I could think of.
       1c. "Operating System" is not acronymed in Hebrew.
       1d. "2x" remains as-is in Hebrew, despite "x" being a Latin character.
       1e. "large screen fix" is translated as "fix for large screen".
       1f. "Caps" in "Caps Lock" is staying untranslated for the time being, until I manage to figure out how it should be called in Hebrew (the concept of capital letters does not exist in Hebrew).
   2. Due to RTL and LTR being in the same sentence in some cases, we will need to find a workaround to get the sentence to be shown as it should, rather than being cut in the middle (for example: "To login* Enter* press on Space or", or "...Password").

*Login and Enter have the same word in Hebrew, though obviously slightly different meanings, and the Enter key does not have a Hebrew name.