### PR TITLE
Don't add DEFAULT_BG if other backgrounds found

### DIFF
--- a/src/themer.js
+++ b/src/themer.js
@@ -44,7 +44,7 @@ export function backgrounds() {
         result.push('file://' + bg);
     }
 
-    return [DEFAULT_BG, ...result];
+    return result;
 }
 
 function getBackground() {


### PR DESCRIPTION
This fixes an issue which I have been having that if you got one image in /usr/share/backgrounds/

If you only have one image in /usr/share/backgrounds, and you want lightdm to display that image, it would switch randomly between that one image and the DEFAULT_BG.

DEFAULT_BG is already returned in getBackgrounds() if no background was defined or found, so adding it in backgrounds() makes not much sense, since that way `localStorage.getItem('background')` is always already set and the "or" case never actually happens