### PR TITLE
Update the README to reflect Arch package version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,31 @@
 # Litarvan's LightDM WebKit2 theme
 
-[![Arch Release](https://img.shields.io/badge/arch-2.0.7-blue.svg?style=flat-square)](https://www.archlinux.org/packages/community/any/lightdm-webkit-theme-litarvan/)&nbsp; [![Latest Release](https://img.shields.io/github/release/Litarvan/lightdm-webkit-theme-litarvan.svg?style=flat-square&label=github)](https://github.com/Litarvan/lightdm-webkit-theme-litarvan/releases) &nbsp;![Github downloads](https://img.shields.io/github/downloads/Litarvan/lightdm-webkit-theme-litarvan/total.svg?style=flat-square)
+[![Arch Release](https://img.shields.io/badge/arch-3.0.0-blue.svg?style=flat-square)](https://www.archlinux.org/packages/community/any/lightdm-webkit-theme-litarvan/)&nbsp; [![Latest Release](https://img.shields.io/github/release/Litarvan/lightdm-webkit-theme-litarvan.svg?style=flat-square&label=github)](https://github.com/Litarvan/lightdm-webkit-theme-litarvan/releases) &nbsp;![Github downloads](https://img.shields.io/github/downloads/Litarvan/lightdm-webkit-theme-litarvan/total.svg?style=flat-square)
 
 **=> Screenshots below**
 
 # [Live testing (3.0.0)](https://litarvan.github.io/lightdm-webkit-theme-litarvan/)
 
 # Customize release
-Backgrounds can be added in /usr/share/backgrounds and chosen in the Theming view (bottom right corner of the Setup view).
+Backgrounds can be added in `/usr/share/backgrounds` and chosen in the Theming view (bottom right corner of the Setup view).
 
 Customize the OS logo within `/usr/share/lightdm-webkit/themes/litarvan/img/os.xxxxxxxx.png`
 
 # Installation
 
-## Arch Linux (2.0.X)
+## Arch Linux (3.0.0)
 
 ```
 pacman -S lightdm-webkit-theme-litarvan
 ```
 
-If not already done, edit `/etc/lightdm/lightdm.conf` and set `greeter-session=lightdm-webkit2-greeter`.
-Then edit `/etc/lightdm/lightdm-webkit.conf` and set `theme` or `webkit-theme` to `litarvan`.
+* If not already done, edit `/etc/lightdm/lightdm.conf` and set `greeter-session=lightdm-webkit2-greeter`.
+* Then edit `/etc/lightdm/lightdm-webkit.conf` and set `theme` or `webkit-theme` to `litarvan`.
 
 ## Manual (3.0.0)
 
 * Install lightdm-webkit2-greeter using pacman if not already done
-* Unzip the [tar file](https://github.com/Litarvan/lightdm-webkit-theme-litarvan/releases) in `/usr/share/lightdm-webkit/themes/litarvan/`
+* Download and unzip the [tar file](https://github.com/Litarvan/lightdm-webkit-theme-litarvan/releases) in `/usr/share/lightdm-webkit/themes/litarvan/`
 * Edit `/etc/lightdm/lightdm-webkit2-greeter.conf` and set `theme` or `webkit-theme` to `litarvan`.
 
 # Building


### PR DESCRIPTION
The Arch Linux package for the theme is at version 3.0.0 as can be seen on the [package page](https://www.archlinux.org/packages/community/any/lightdm-webkit-theme-litarvan/) and in the [PKGBUILD](https://git.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/lightdm-webkit-theme-litarvan) file. The install instructions in the README have been changed to reflect this.