### PR TITLE
Update translations.js to add Chinese (Simplified) and Chinese (Traditional)

### DIFF
--- a/src/translations.js
+++ b/src/translations.js
@@ -122,7 +122,7 @@ const translations = {
         primaryColor: 'צבע ראשי'
     },
     // Chinese (Simplified)
-    'zh_CN': {
+    'zh-CN': {
         trigger: '按空格或回车登录',
         password: '密码……',
 
@@ -149,7 +149,7 @@ const translations = {
         bgAdd: '背景图片可以添加至以下目录：'
     },
     // Chinese (Traditional)
-    'zh_TW': {
+    'zh-TW': {
         trigger: '按下空格鍵或輸入鍵登入',
         password: '密碼……',
 

--- a/src/translations.js
+++ b/src/translations.js
@@ -121,7 +121,60 @@ const translations = {
 
         primaryColor: 'צבע ראשי'
     },
+    // Chinese (Simplified)
+    'zh_CN': {
+        trigger: '按空格或回车登录',
+        password: '密码……',
 
+        shutdown: '正在关机……',
+        hibernate: '正在休眠……',
+        suspend: '正在挂起……',
+        restart: '正在重新启动……',
+
+        setup: '设置',
+        theming: '主题',
+        disableSplash: '禁用启动屏幕（“按回车登录”界面）',
+        disableSplashText: '禁用启动屏幕文本（仅时钟）',
+        disableIntro: '禁用切入画面（操作系统的Logo）',
+        disableFade: '禁用登录后淡入至黑屏',
+        roundAvatar: '圆形头像',
+        disableAvatar: '禁用头像',
+        disableZoom: '禁用两倍（2x）放大（大屏幕修复）',
+        clock12: '12小时制',
+        disablePowerTexts: '禁用“正在关机……”等屏幕',
+        capsLock: '已启用大写锁定',
+
+        primaryColor: '主题色',
+        randomizeBG: '每一次选择随机背景',
+        bgAdd: '背景图片可以添加至以下目录：'
+    },
+    // Chinese (Traditional)
+    'zh_TW': {
+        trigger: '按下空格鍵或輸入鍵登入',
+        password: '密碼……',
+
+        shutdown: '正在關機……',
+        hibernate: '正在休眠……',
+        suspend: '正在暫停……',
+        restart: '正在重新啟動……',
+
+        setup: '設定',
+        theming: '佈景主題',
+        disableSplash: '停用 Splash Screen（「按下輸入鍵登入」畫面）',
+        disableSplashText: '停用 Splash 文字（僅時鐘）',
+        disableIntro: '停用 Intro（作業系統的Logo）',
+        disableFade: '停用登入後淡入至黑色',
+        roundAvatar: '圓形頭像',
+        disableAvatar: '停用頭像',
+        disableZoom: '停用 2x 放大（大螢幕修復）',
+        clock12: '12小時制',
+        disablePowerTexts: '停用「正在關機……」等畫面',
+        capsLock: '已啟用大寫鎖定',
+
+        primaryColor: '主要顏色',
+        randomizeBG: '每一次選擇隨機桌布',
+        bgAdd: '桌布可加入至：'
+    },
     // More ? PR opens !
 };
 


### PR DESCRIPTION
I'm using this greeter theme starting today because I hate to have a functional GNOME while actually using KDE (sddm has some bug so I had to give up). It's a really nice lightdm theme, but it can be better to have Chinese support!
I don't know whether it supports language fallback (because there are many "variants" of Chinese, and all of them eventually can be split into Simplified and Traditional). That is, "zh_Hant" "zh_TW" "zh_HK" (idk if there's more in Linux locale) should use "zh_TW" texts in the translation. "zh_CN" (and if there's "zh_Hans" or more Linux locale) should use "zh_CN" texts in the translation. "zh" is for fallback of Chinese, and idk if I should actually set this to any of them, but by default in MediaWiki "zh" is fallback to "zh_CN".
Hope that you can accept my pull request.