### PR TITLE
Fix dirlist not traversing subfolders in web-greeter ^3.0

### DIFF
--- a/src/themer.js
+++ b/src/themer.js
@@ -43,7 +43,7 @@ export async function backgrounds() {
         let result = [];
         let dirlist = [];
         await new Promise((resolve) => {
-            let dirl = theme_utils.dirlist(dir, true, (files) => {
+            let dirl = theme_utils.dirlist(dir, false, (files) => {
                 dirlist = files;
                 resolve();
             })


### PR DESCRIPTION
Fixes JezerM/web-greeter#50

## Changes

- Changed `theme_utils.dirlist` only_images parameter to **false**, so the theme could now list folders and traverse them.