### PR TITLE
chore: remove legacy build

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "browserslist": [
     "> 1%",
-    "last 2 versions",
+    "last 2 years",
+    "not dead",
     "not ie <= 8"
   ]
 }


### PR DESCRIPTION
This commit removes vue-cli's legacy build. Speeds up build and reduces build size.